### PR TITLE
feat(analytics): add user streak tracking and update logic

### DIFF
--- a/apps/analytics-ms/src/analytics-ms.service.ts
+++ b/apps/analytics-ms/src/analytics-ms.service.ts
@@ -10,6 +10,7 @@ import { UserActivitySession } from './entity/user-activity-session.entity';
 import { DocumentActivitySession } from './entity/document-activity-session.entity';
 import { Repository } from 'typeorm';
 import { UserStreak } from './entity/user-streak.entity';
+import { startOfDay, subDays, isSameDay } from 'date-fns';
 
 @Injectable()
 export class AnalyticsMsService {
@@ -59,6 +60,23 @@ export class AnalyticsMsService {
 
       const saved = await this.userActivityRepo.save(log);
 
+      if (role === 'STUDENT' || role === 'TUTOR') {
+        // Check last_active_date first
+        const streak = await this.userStreakRepo.findOne({
+          where: { user_id },
+        });
+        const today = startOfDay(new Date());
+
+        if (
+          !streak ||
+          !streak.last_active_date ||
+          !isSameDay(streak.last_active_date, today)
+        ) {
+          // Only call update if the user hasn't been active today
+          await this.updateUserStreak(user_id);
+        }
+      }
+
       this.logger.debug(
         `Activity logged: ${activity_type} by ${role} (${user_id})`,
       );
@@ -75,5 +93,48 @@ export class AnalyticsMsService {
         message: 'Failed to log user activity',
       };
     }
+  }
+
+  // ---------------------------
+  // Update streak logic
+  // ---------------------------
+  private async updateUserStreak(user_id: string) {
+    const today = startOfDay(new Date());
+
+    let streak = await this.userStreakRepo.findOne({ where: { user_id } });
+
+    if (!streak) {
+      streak = this.userStreakRepo.create({
+        user_id,
+        current_streak_days: 1,
+        longest_streak_days: 1,
+        last_active_date: today,
+      });
+    } else {
+      const lastActive = streak.last_active_date
+        ? startOfDay(streak.last_active_date)
+        : null;
+
+      if (lastActive && isSameDay(lastActive, today)) {
+        // Already updated today → do nothing
+        return streak;
+      }
+
+      const yesterday = subDays(today, 1);
+      if (lastActive && isSameDay(lastActive, yesterday)) {
+        streak.current_streak_days += 1; // Increment streak
+      } else {
+        streak.current_streak_days = 1; // Reset streak
+      }
+
+      // Update longest streak if needed
+      if (streak.current_streak_days > streak.longest_streak_days) {
+        streak.longest_streak_days = streak.current_streak_days;
+      }
+
+      streak.last_active_date = today;
+    }
+
+    return this.userStreakRepo.save(streak);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
         "csv-parser": "^3.2.0",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.2.2",
         "multer": "^2.0.2",
         "nodemailer": "^7.0.6",
@@ -10405,6 +10406,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
     "csv-parser": "^3.2.0",
+    "date-fns": "^4.1.0",
     "dotenv": "^17.2.2",
     "multer": "^2.0.2",
     "nodemailer": "^7.0.6",


### PR DESCRIPTION
This pull request introduces user streak tracking for activity logging in the analytics microservice. The main changes include adding logic to update user streaks for students and tutors, implementing a helper method to manage streak calculations, and adding the `date-fns` library for date operations.

**User streak tracking enhancements:**

* Added logic to update user streaks in the `logUserActivity` method for users with the `STUDENT` or `TUTOR` role, ensuring streaks are only updated if the user hasn't been active today.
* Implemented a new private method `updateUserStreak` in `AnalyticsMsService` to calculate and persist current and longest streaks based on daily activity, using date comparisons to increment or reset streaks.

**Dependencies:**

* Added the `date-fns` library to `package.json` to support reliable date calculations for streak logic.

**Imports:**

* Imported necessary functions (`startOfDay`, `subDays`, `isSameDay`) from `date-fns` in `analytics-ms.service.ts` to facilitate streak calculations.